### PR TITLE
Fix support for translations in path that contain URI-escaped characters

### DIFF
--- a/src/main/java/org/jtwig/translate/message/source/localized/provider/ClasspathLocalizedResourceProvider.java
+++ b/src/main/java/org/jtwig/translate/message/source/localized/provider/ClasspathLocalizedResourceProvider.java
@@ -35,7 +35,8 @@ public class ClasspathLocalizedResourceProvider implements LocalizedResourceProv
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
                 if (FILE_PROTOCOL.contains(resource.getProtocol())) {
-                    File baseDirectory = new File(resource.getFile(), basePackage.replace(".", File.separator));
+                    final String path = URLDecoder.decode(resource.getFile(), "UTF-8");
+                    File baseDirectory = new File(path, basePackage.replace(".", File.separator));
                     Collection<File> files = fileFinder.find(baseDirectory, fileFilter);
                     for (File file : files) {
                         result.add(ResourceReference.file(file));
@@ -44,6 +45,8 @@ public class ClasspathLocalizedResourceProvider implements LocalizedResourceProv
             }
         } catch (IOException e) {
             throw new ResourceException("Cannot load classpath root directories", e);
+        } catch (UnsupportedEncodingException e){
+            throw new ResourceException("Cannot decode classpath root directories", e);
         }
         return result;
     }


### PR DESCRIPTION
I was trying to use jtwig translation but it never worked. After debugging i noticed that the path my application is running in contains whitespaces, which get escaped in the URL but are never unescaped when resolving the file.

Example: 
\CORE backend\core\target\classes\translations -> \CORE%20backend\core\target\classes\translations

Both versions are valid paths on my OS but not the same.